### PR TITLE
Run post-processing in Go to fix build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ This repository is a prototype of code generation from GitHub's OpenAPI specific
 ## Execution
 
 1. To generate the .NET package, run from the root of the repo: `openapi-generator-cli generate -i schemas/api.github.com/api.github.com.2022-11-28.json -t templates/dotnet -g csharp -o generated/dotnet -p packageName=Octokit`. Alternately, you may run the provided script `generate.sh`.
-
 1. To build the .NET package, change directories into generated/dotnet and run `chmod +x build.sh`, followed by `./build.sh`.

--- a/csharp-post-process.sh
+++ b/csharp-post-process.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+filename=$1
+
+echo "Running post-process script on $filename"
+
+go run post-process/cmd/dotnet/main.go $filename

--- a/generate.sh
+++ b/generate.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env sh
 
-openapi-generator-cli generate -i schemas/api.github.com/api.github.com.2022-11-28.json -t templates/dotnet -g csharp -o generated/dotnet -p packageName=Octokit
+export CSHARP_POST_PROCESS_FILE="/home/kfcampbell/github/dev/source-generator/csharp-post-process.sh"
+
+openapi-generator-cli generate -i schemas/api.github.com/api.github.com.2022-11-28.json -t templates/dotnet -g csharp -o generated/dotnet -p packageName=Octokit --enable-post-process-file
+
+

--- a/post-process/cmd/dotnet/main.go
+++ b/post-process/cmd/dotnet/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+
+}
+
+func run() error {
+	if len(os.Args) != 2 {
+		return fmt.Errorf("exactly one filename must be provided to run post-processing on")
+	}
+	filename := os.Args[1]
+	log.Printf("running post processing on file %v", filename)
+
+	// open file
+	fileBytes, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	file := string(fileBytes)
+	file, err = fixDoubleStarProperties(file)
+	if err != nil {
+		return err
+	}
+
+	// todo(kfcampbell): verify file permission is what we want
+	err = os.WriteFile(filename, []byte(file), 0666)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// fixDoubleStarProperties returns the input string with
+func fixDoubleStarProperties(inputFile string) (string, error) {
+	if len(inputFile) < 1 {
+		return "", fmt.Errorf("inputFile must not be empty")
+	}
+
+	// find instances of "/// Enum Star for value: *" and replace with "Enum All for value: *"
+	inputFile = strings.ReplaceAll(inputFile, "/// Enum Star for value: *", "/// Enum All for value: *")
+
+	// find instances of "            Star = 1," and replace with "            All = 1,"
+	inputFile = strings.ReplaceAll(inputFile, "            Star = 1,", "            All = 1,")
+	return inputFile, nil
+}


### PR DESCRIPTION
Currently the .NET SDK's build is broken due to the three different classes of build errors detailed in #1. This PR introduces post-processing in Go to the repo and fixes (currently) one class of the build errors. 